### PR TITLE
Fix row slice allocation

### DIFF
--- a/pkg/grid/grid.go
+++ b/pkg/grid/grid.go
@@ -10,7 +10,7 @@ type Grid[T comparable] [][]T
 
 func New[T comparable](rows, cols int) Grid[T] {
 	grid := make([][]T, rows)
-	for i := range rows {
+	for i := 0; i < rows; i++ {
 		grid[i] = make([]T, cols)
 	}
 	return grid


### PR DESCRIPTION
## Summary
- fix allocation loop when creating a grid

## Testing
- `go vet ./...`
- `go test ./...` *(fails: flag provided but not defined: -test.testlogfile)*

------
https://chatgpt.com/codex/tasks/task_e_6842b22fa1ec832581fbb8f8dff2af79