### PR TITLE
Fix tests and delay flag parsing

### DIFF
--- a/pkg/aoc/challenge.go
+++ b/pkg/aoc/challenge.go
@@ -35,27 +35,26 @@ func New[T any, R comparable](year, day int, inputProcessor InputProcessor[T], p
 }
 
 func (d *Challenge[T, R]) setup() {
-	// Parse args flags
-	debug := flag.Bool("debug", false, "sets log level to debug")
-	part := flag.Int("p", 0, "runs only the specified part")
-	runTests := flag.Bool("test", false, "runs tests")
-	flag.Parse()
-	// Set up logger
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
-	zerolog.DurationFieldUnit = time.Microsecond
-	zerolog.SetGlobalLevel(zerolog.ErrorLevel)
-	if *debug {
-		zerolog.SetGlobalLevel(zerolog.DebugLevel)
-	}
-	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
-	d.debug = *debug
-	d.runPart = *part
-	d.runTests = *runTests
-	// input file if provided
-	d.inputFile = flag.Arg(0)
+	// register flags
+	flag.BoolVar(&d.debug, "debug", false, "sets log level to debug")
+	flag.IntVar(&d.runPart, "p", 0, "runs only the specified part")
+	flag.BoolVar(&d.runTests, "test", false, "runs tests")
 }
 
 func (d *Challenge[T, R]) Run() {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+	// Set up logger after parsing flags
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+	zerolog.DurationFieldUnit = time.Microsecond
+	zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+	if d.debug {
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	}
+	log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	d.inputFile = flag.Arg(0)
+
 	defer func() {
 		if r := recover(); r != nil {
 			log.Error().Msgf("Recovered from panic: %v", r)

--- a/test/collections_test.go
+++ b/test/collections_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"fmt"
 	"slices"
 	"testing"
 
@@ -27,7 +26,6 @@ func TestDiff(t *testing.T) {
 
 	for _, c := range cases {
 		got := collections.Diff(c.a, c.b)
-		fmt.Println(got)
 		slices.Sort(got)
 		slices.Sort(c.want)
 		if slices.Compare(got, c.want) != 0 {
@@ -77,6 +75,10 @@ func TestCombinations(t *testing.T) {
 
 	for _, c := range cases {
 		got := collections.Combinations(c.input, c.size)
+		if len(got) != len(c.expected) {
+			t.Errorf("Combinations(%v, %v) produced %d results, want %d", c.input, c.size, len(got), len(c.expected))
+			continue
+		}
 		for i, g := range got {
 			if slices.Compare(g, c.expected[i]) != 0 {
 				t.Errorf("Combinations(%v, %v) == %v, want %v", c.input, c.size, got, c.expected)


### PR DESCRIPTION
## Summary
- remove debug print from `TestDiff`
- verify combination lengths before iterating
- register CLI flags and parse them only when running `Run`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6842b2026cd48325b5be92f634f4ef58