### PR TITLE
Add unit tests for pkg modules

### DIFF
--- a/pkg/aoc/input_processor_test.go
+++ b/pkg/aoc/input_processor_test.go
@@ -1,0 +1,67 @@
+package aoc
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestStringProcessor(t *testing.T) {
+	if StringProcessor(" a \n") != "a" {
+		t.Fatalf("trim failed")
+	}
+}
+
+func TestLinesProcessor(t *testing.T) {
+	proc := LinesProcessor()
+	lines := proc("a\nb")
+	if !reflect.DeepEqual(lines, []string{"a", "b"}) {
+		t.Fatalf("lines processor failed")
+	}
+}
+
+func TestIntLinesProcessor(t *testing.T) {
+	ints := IntLinesProcessor("1\n2")
+	if len(ints) != 2 || ints[0] != 1 || ints[1] != 2 {
+		t.Fatalf("int lines processor failed")
+	}
+}
+
+func TestGridStringProcessor(t *testing.T) {
+	proc := GridStringProcessor()
+	grid := proc("ab\ncd")
+	if grid[1][1] != "d" {
+		t.Fatalf("grid string processor failed")
+	}
+}
+
+func TestRuneGridProcessor(t *testing.T) {
+	g := RuneGridProcessor("ab\ncd")
+	if *g.Get(1, 1) != 'd' {
+		t.Fatalf("rune grid failed")
+	}
+}
+
+func TestIntGridProcessor(t *testing.T) {
+	g := IntGridProcessor("12\n34")
+	if *g.Get(1, 0) != 3 {
+		t.Fatalf("int grid failed")
+	}
+}
+
+func TestInts2dProcessor(t *testing.T) {
+	splitter := func(s string) []string { return strings.Split(s, ",") }
+	proc := Ints2dProcessor(splitter)
+	res := proc("1,2\n3,4")
+	if res[1][1] != 4 {
+		t.Fatalf("ints2d failed")
+	}
+}
+
+func TestGridProcessor(t *testing.T) {
+	proc := GridProcessor(func(r rune) int { return int(r - '0') })
+	g := proc("12\n34")
+	if *g.Get(1, 1) != 4 {
+		t.Fatalf("grid processor failed")
+	}
+}

--- a/pkg/aoc/utils_test.go
+++ b/pkg/aoc/utils_test.go
@@ -1,0 +1,15 @@
+package aoc
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestGetSourceFilePath(t *testing.T) {
+	_, this, _, _ := runtime.Caller(0)
+	expected := filepath.Join(filepath.Dir(this), "file")
+	if GetSourceFilePath("file") != expected {
+		t.Fatalf("path mismatch")
+	}
+}

--- a/pkg/deque/deque_test.go
+++ b/pkg/deque/deque_test.go
@@ -1,0 +1,30 @@
+package deque
+
+import "testing"
+
+func TestPushPop(t *testing.T) {
+	d := New[int]()
+	d.PushBack(1)
+	d.PushBack(2)
+	d.PushFront(0)
+	if v := d.PopFront(); v == nil || *v != 0 {
+		t.Fatalf("expected 0")
+	}
+	if v := d.PopBack(); v == nil || *v != 2 {
+		t.Fatalf("expected 2")
+	}
+}
+
+func TestSeq(t *testing.T) {
+	d := New[int](1, 2, 3)
+	var res []int
+	for v := range d.SeqFront() {
+		res = append(res, v)
+	}
+	expected := []int{1, 2, 3}
+	for i := range expected {
+		if res[i] != expected[i] {
+			t.Fatalf("unexpected seq")
+		}
+	}
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,15 @@
+package errors
+
+import "fmt"
+import "testing"
+
+func TestMustReturnsValue(t *testing.T) {
+	if Must(1, nil) != 1 {
+		t.Errorf("expected 1")
+	}
+}
+
+func TestMustPanics(t *testing.T) {
+	defer func() { recover() }()
+	Must(0, fmt.Errorf("err"))
+}

--- a/pkg/fn/func_test.go
+++ b/pkg/fn/func_test.go
@@ -1,0 +1,16 @@
+package fn
+
+import "testing"
+
+func TestIdentity(t *testing.T) {
+	if Identity(42) != 42 {
+		t.Errorf("expected 42")
+	}
+}
+
+func TestEq(t *testing.T) {
+	eq := Eq(5)
+	if !eq(5) || eq(4) {
+		t.Errorf("eq function failed")
+	}
+}

--- a/pkg/graph/graph_test.go
+++ b/pkg/graph/graph_test.go
@@ -1,0 +1,53 @@
+package graph
+
+import "testing"
+
+func simpleGraph() *Graph[int, int] {
+	g := New[int, int]()
+	g.AddOneWayEdge(1, 2, 1, 0)
+	g.AddOneWayEdge(2, 3, 1, 0)
+	g.AddOneWayEdge(1, 3, 10, 0)
+	return g
+}
+
+func TestHasEdge(t *testing.T) {
+	g := simpleGraph()
+	if !g.HasEdge(1, 2) || g.HasEdge(3, 1) {
+		t.Fatalf("has edge failed")
+	}
+}
+
+func TestNeighbors(t *testing.T) {
+	g := simpleGraph()
+	n := g.Neighbors(1)
+	if len(n) != 2 {
+		t.Fatalf("neighbors failed")
+	}
+}
+
+func TestGetEdge(t *testing.T) {
+	g := simpleGraph()
+	e := g.GetEdge(1, 2)
+	if e == nil || *e.To != 2 || e.Weight != 1 {
+		t.Fatalf("get edge failed")
+	}
+}
+
+func TestShortestPath(t *testing.T) {
+	g := simpleGraph()
+	p := g.FindShortestPathBetween(1, 3)
+	if len(p) != 3 || p[0] != 1 || p[2] != 3 {
+		t.Fatalf("shortest path failed")
+	}
+}
+
+func TestShortestPaths(t *testing.T) {
+	g := New[int, int]()
+	g.AddOneWayEdge(1, 2, 1, 0)
+	g.AddOneWayEdge(1, 3, 2, 0)
+	g.AddOneWayEdge(2, 3, 1, 0)
+	paths := g.FindShortestPathsBetween(1, 3)
+	if len(paths) != 2 {
+		t.Fatalf("expected two paths")
+	}
+}

--- a/pkg/maps2/map_test.go
+++ b/pkg/maps2/map_test.go
@@ -1,0 +1,36 @@
+package maps2
+
+import "testing"
+
+func TestMapBasic(t *testing.T) {
+	m := New[int, int](NewEntry(1, 1))
+	if v, ok := m.Get(1); !ok || v != 1 {
+		t.Fatalf("get failed")
+	}
+	m.Set(2, 2)
+	if !m.Has(2) {
+		t.Fatalf("has failed")
+	}
+	m.Delete(2)
+	if m.Has(2) {
+		t.Fatalf("delete failed")
+	}
+	if len(m.Keys()) != 1 {
+		t.Fatalf("keys failed")
+	}
+	if len(m.Values()) != 1 {
+		t.Fatalf("values failed")
+	}
+	clone := m.Clone()
+	if len(clone) != 1 || clone[1] != 1 {
+		t.Fatalf("clone failed")
+	}
+}
+
+func TestMapAddI(t *testing.T) {
+	m := New[int, int]()
+	m2 := m.AddI(NewEntry(1, 1))
+	if m.Has(1) || !m2.Has(1) {
+		t.Fatalf("AddI failed")
+	}
+}

--- a/pkg/maps2/multimap_test.go
+++ b/pkg/maps2/multimap_test.go
@@ -1,0 +1,13 @@
+package maps2
+
+import "testing"
+
+func TestMultiMap(t *testing.T) {
+	m := NewMultiMap[int, int]()
+	m.Add(1, 1)
+	m.Add(1, 2)
+	vals := m.Get(1)
+	if len(vals) != 2 || vals[0] != 1 || vals[1] != 2 {
+		t.Fatalf("multimap failed")
+	}
+}

--- a/pkg/math2/math_extra_test.go
+++ b/pkg/math2/math_extra_test.go
@@ -1,0 +1,40 @@
+package math2
+
+import "testing"
+
+func TestArray2D3D(t *testing.T) {
+	a := Array2D[int](2, 3)
+	if len(a) != 2 || len(a[0]) != 3 {
+		t.Fatalf("array2d failed")
+	}
+	b := Array3D[int](2, 2, 2)
+	if len(b) != 2 || len(b[0]) != 2 || len(b[0][0]) != 2 {
+		t.Fatalf("array3d failed")
+	}
+}
+
+func TestRotateMatrix(t *testing.T) {
+	m := [][]int{{1, 2}, {3, 4}}
+	r := RotateMatrix(m)
+	if r[0][0] != 3 || r[1][0] != 4 {
+		t.Fatalf("rotate failed")
+	}
+}
+
+func TestMathHelpers(t *testing.T) {
+	if Max(2, 3) != 3 || Min(2, 3) != 2 {
+		t.Fatalf("max/min failed")
+	}
+	if Abs(-2) != 2 {
+		t.Fatalf("abs failed")
+	}
+	if Floor(3.7) != 3 {
+		t.Fatalf("floor failed")
+	}
+	if Log10(100.0) != 2 {
+		t.Fatalf("log10 failed")
+	}
+	if Power(2, 3) != 8 {
+		t.Fatalf("power failed")
+	}
+}

--- a/pkg/queue/priority_queue_test.go
+++ b/pkg/queue/priority_queue_test.go
@@ -1,0 +1,50 @@
+package queue
+
+import "testing"
+
+func TestPriorityQueuePushPop(t *testing.T) {
+	pq := NewPriorityQueue[int]()
+	pq.PushValue(3, 3)
+	pq.PushValue(1, 1)
+	pq.PushValue(2, 2)
+	if v := pq.PopValue(); v != 1 {
+		t.Fatalf("expected 1")
+	}
+	if v := pq.PopValue(); v != 2 {
+		t.Fatalf("expected 2")
+	}
+	if v := pq.PopValue(); v != 3 {
+		t.Fatalf("expected 3")
+	}
+}
+
+func TestPriorityQueueSeq(t *testing.T) {
+	pq := NewPriorityQueue[int]()
+	pq.PushValue(1, 1)
+	pq.PushValue(2, 2)
+	pq.PushValue(3, 3)
+	var res []int
+	for v := range pq.Seq() {
+		res = append(res, v)
+	}
+	expected := []int{1, 2, 3}
+	for i := range expected {
+		if res[i] != expected[i] {
+			t.Fatalf("seq mismatch")
+		}
+	}
+}
+
+func TestPriorityQueueSeqPriority(t *testing.T) {
+	pq := NewPriorityQueue[int]()
+	pq.PushValue(1, 1)
+	pq.PushValue(2, 2)
+	pq.PushValue(3, 3)
+	var res []int
+	for v, p := range pq.SeqPriority() {
+		res = append(res, v+p)
+	}
+	if len(res) != 3 {
+		t.Fatalf("expected 3 elements")
+	}
+}

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -1,0 +1,29 @@
+package queue
+
+import "testing"
+
+func TestQueuePushPop(t *testing.T) {
+	q := New[int]()
+	q.Push(1)
+	q.Push(2)
+	if v := q.Pop(); v == nil || *v != 1 {
+		t.Fatalf("expected 1")
+	}
+	if v := q.Pop(); v == nil || *v != 2 {
+		t.Fatalf("expected 2")
+	}
+}
+
+func TestQueueSeq(t *testing.T) {
+	q := New[int](1, 2, 3)
+	var res []int
+	for v := range q.Seq() {
+		res = append(res, v)
+	}
+	expected := []int{1, 2, 3}
+	for i := range expected {
+		if res[i] != expected[i] {
+			t.Fatalf("seq mismatch")
+		}
+	}
+}

--- a/pkg/set/set_test.go
+++ b/pkg/set/set_test.go
@@ -1,0 +1,39 @@
+package set
+
+import "testing"
+
+func TestSetBasic(t *testing.T) {
+	s := New[int]()
+	s.Add(1)
+	if !s.Contains(1) {
+		t.Fatalf("set should contain 1")
+	}
+	if s.Len() != 1 {
+		t.Fatalf("len expected 1")
+	}
+	s.Remove(1)
+	if s.Contains(1) {
+		t.Fatalf("remove failed")
+	}
+}
+
+func TestSetUnionIntersection(t *testing.T) {
+	s1 := New(1, 2)
+	s2 := New(2, 3)
+	u := s1.Union(s2)
+	if !u.Equals(New(1, 2, 3)) {
+		t.Fatalf("union failed")
+	}
+	i := s1.Intersection(s2)
+	if !i.Equals(New(2)) {
+		t.Fatalf("intersection failed")
+	}
+	d := s1.Difference(s2)
+	if !d.Equals(New(1)) {
+		t.Fatalf("difference failed")
+	}
+	sym := s1.SymmetricDifference(s2)
+	if !sym.Equals(New(1, 3)) {
+		t.Fatalf("symmetric difference failed")
+	}
+}

--- a/pkg/strings2/strings_test.go
+++ b/pkg/strings2/strings_test.go
@@ -1,0 +1,38 @@
+package strings2
+
+import "testing"
+
+func TestReverseString(t *testing.T) {
+	if ReverseString("abc") != "cba" {
+		t.Fatalf("reverse failed")
+	}
+}
+
+func TestMapToInt(t *testing.T) {
+	res := MapToInt([]string{"1", "2", "3"})
+	expected := []int{1, 2, 3}
+	for i := range expected {
+		if res[i] != expected[i] {
+			t.Fatalf("map failed")
+		}
+	}
+}
+
+func TestMapCharsToInts(t *testing.T) {
+	res := MapCharsToInts([]rune("12"))
+	if len(res) != 2 || res[0] != 1 || res[1] != 2 {
+		t.Fatalf("map chars failed")
+	}
+}
+
+func TestAtoi(t *testing.T) {
+	if Atoi[int]("42") != 42 {
+		t.Fatalf("atoi failed")
+	}
+	if Atoi[int64]("42") != 42 {
+		t.Fatalf("atoi int64 failed")
+	}
+	if Atoi[float64]("3.5") != 3.5 {
+		t.Fatalf("atoi float failed")
+	}
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func createCache(year, day int, data string) {
+	os.Mkdir(".cache", 0755)
+	os.WriteFile(filepath.Join(".cache", fmt.Sprintf("input_%d_%d.txt", year, day)), []byte(data), 0644)
+}
+
+func TestReadInputFromCache(t *testing.T) {
+	year, day := 9999, 1
+	createCache(year, day, "data\nline2\n")
+	res, err := ReadInput(year, day)
+	if err != nil || res != "data\nline2\n" {
+		t.Fatalf("cache read failed")
+	}
+}
+
+func TestReadInputLines(t *testing.T) {
+	year, day := 9999, 2
+	createCache(year, day, "a\nb\n")
+	lines, err := ReadInputLines(year, day)
+	if err != nil || len(lines) != 2 || lines[0] != "a" || lines[1] != "b" {
+		t.Fatalf("read lines failed")
+	}
+}
+
+func TestReadInputSlice2d(t *testing.T) {
+	year, day := 9999, 3
+	createCache(year, day, "ab\ncd\n")
+	slice, err := ReadInputSlice2d(year, day)
+	if err != nil || len(slice) != 2 || slice[0][0] != "a" || slice[1][1] != "d" {
+		t.Fatalf("slice2d failed")
+	}
+}

--- a/test/collections_extra_test.go
+++ b/test/collections_extra_test.go
@@ -1,0 +1,65 @@
+package test
+
+import (
+	"slices"
+	"strconv"
+	"testing"
+
+	"manoamaro.github.com/advent-of-code/pkg/collections"
+)
+
+func TestMapFunctions(t *testing.T) {
+	r := collections.Map([]int{1, 2, 3}, func(i int) int { return i * 2 })
+	if !slices.Equal(r, []int{2, 4, 6}) {
+		t.Fatalf("map failed")
+	}
+	r2 := collections.MapNotError([]string{"1", "a"}, func(s string) (int, error) { return strconv.Atoi(s) })
+	if !slices.Equal(r2, []int{1}) {
+		t.Fatalf("mapnoterror failed")
+	}
+}
+
+func TestFlatMapFoldReverse(t *testing.T) {
+	fm := collections.FlatMap([][]int{{1, 2}, {3}}, func(s []int) []int { return s })
+	if !slices.Equal(fm, []int{1, 2, 3}) {
+		t.Fatalf("flatmap failed")
+	}
+	sum := collections.Fold([]int{1, 2, 3}, 0, func(a, b int) int { return a + b })
+	if sum != 6 {
+		t.Fatalf("fold failed")
+	}
+	rev := collections.Reverse([]int{1, 2, 3})
+	if !slices.Equal(rev, []int{3, 2, 1}) {
+		t.Fatalf("reverse failed")
+	}
+}
+
+func TestOtherCollectionFuncs(t *testing.T) {
+	seq := collections.SlideSeq([]int{1, 2, 3}, 2)
+	var got [][]int
+	for s := range seq {
+		got = append(got, s)
+	}
+	if len(got) != 2 {
+		t.Fatalf("slideseq failed")
+	}
+	del := collections.Delete([]int{1, 2, 3}, 1)
+	if !slices.Equal(del, []int{1, 3}) {
+		t.Fatalf("delete failed")
+	}
+	first := collections.FirstFunc([]int{1, 2, 3}, func(i int) bool { return i == 2 })
+	if first == nil || *first != 2 {
+		t.Fatalf("firstfunc failed")
+	}
+	filt := collections.FilterFunc([]int{1, 2, 3}, func(i int) bool { return i > 1 })
+	if !slices.Equal(filt, []int{2, 3}) {
+		t.Fatalf("filterfunc failed")
+	}
+	prod := collections.ProductFunc([]int{1, 2}, []int{3}, func(a, b int) int { return a + b })
+	if !slices.Equal(prod, []int{4, 5}) {
+		t.Fatalf("productfunc failed")
+	}
+	if collections.Sum([]int{1, 2, 3}) != 6 {
+		t.Fatalf("sum failed")
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for utils, maps2, queue, deque, sets, strings, graph
- test aoc input processors and helpers
- add coverage for errors and fn helpers
- extend math and collections tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6843106f85948325a6d9e41093f5ee8d